### PR TITLE
Refactor v8 bindings to use nan for compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,9 @@
       ],
       'libraries': [
         '-lusb'
+      ],
+      "include_dirs" : [
+          "<!(node -e \"require('nan')\")"
       ]
     },
   ],

--- a/lib/digispark.js
+++ b/lib/digispark.js
@@ -32,9 +32,16 @@ Cylon.Utils.subclass(Digispark, Cylon.Adaptor);
  * @return {void}
  */
 Digispark.prototype.connect = function(callback) {
+  var err;
   this.digispark = new digispark.Digispark();
-  this.proxyMethods(this.commands, this.digispark, this);
-  callback();
+
+  if (this.digispark.digisparkSearch() === 0) {
+    err = new Error("Connection error! Try creating udev rules or run with sudo.");
+  } else {
+    this.proxyMethods(this.commands, this.digispark, this);
+  }
+
+  callback(err);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "cylon":      "1.0.0",
     "cylon-gpio": "0.25.0",
-    "node-gyp":   "2.0.1"
+    "node-gyp":   "2.0.1",
+    "nan":        "1.8.4"
   }
 }

--- a/spec/lib/digispark.spec.js
+++ b/spec/lib/digispark.spec.js
@@ -29,13 +29,16 @@ describe("Digispark", function() {
   });
 
   describe("#connect", function() {
-    var mockSpark = {},
+    var mockSpark = {
+          digisparkSearch: stub()
+        },
         callback;
 
     beforeEach(function() {
       callback = spy();
       stub(digispark, "Digispark").returns(mockSpark);
       stub(spark, "proxyMethods");
+      mockSpark.digisparkSearch.returns(1);
       spark.connect(callback);
     });
 
@@ -124,8 +127,13 @@ describe("Digispark", function() {
     var mockSpark;
 
     beforeEach(function() {
-      mockSpark = { pwmWrite: spy() };
+      mockSpark = {
+        pwmWrite: spy(),
+        digisparkSearch: stub()
+      };
+
       stub(digispark, "Digispark").returns(mockSpark);
+      mockSpark.digisparkSearch.returns(1);
 
       spark.connect(spy());
       spark.pwmWrite("A", 1);

--- a/src/digispark.cc
+++ b/src/digispark.cc
@@ -14,6 +14,7 @@ class Digispark : public node::ObjectWrap {
     ~Digispark();
     static NAN_METHOD(New);
     static NAN_METHOD(FirmwareVersion);
+    static NAN_METHOD(DigisparkSearch);
     static NAN_METHOD(DigitalWrite);
     static NAN_METHOD(DigitalRead);
     static NAN_METHOD(ServoWrite);
@@ -45,6 +46,7 @@ void Digispark::Init(Handle<Object> exports) {
 
   // Prototype
   tpl->PrototypeTemplate()->Set(NanNew("firmwareVersion"),NanNew<FunctionTemplate>(FirmwareVersion)->GetFunction());
+  tpl->PrototypeTemplate()->Set(NanNew("digisparkSearch"),NanNew<FunctionTemplate>(DigisparkSearch)->GetFunction());
   tpl->PrototypeTemplate()->Set(NanNew("pinMode"),NanNew<FunctionTemplate>(PinMode)->GetFunction());
   tpl->PrototypeTemplate()->Set(NanNew("digitalWrite"),NanNew<FunctionTemplate>(DigitalWrite)->GetFunction());
   tpl->PrototypeTemplate()->Set(NanNew("digitalRead"),NanNew<FunctionTemplate>(DigitalRead)->GetFunction());
@@ -71,6 +73,11 @@ NAN_METHOD(Digispark::FirmwareVersion) {
   NanScope();
   Digispark* obj = ObjectWrap::Unwrap<Digispark>(args.This());
   NanReturnValue(NanNew<Number>(readFirmwareVersion(obj->lw_)));
+}
+
+NAN_METHOD(Digispark::DigisparkSearch) {
+  NanScope();
+  NanReturnValue(NanNew<Number>(littlewire_search()));
 }
 
 NAN_METHOD(Digispark::DigitalWrite) {


### PR DESCRIPTION
Adds `nan` as a dependency and uses it to provide support for different versions of v8 without providing our own macros.

I'm unable to test it on an actual Digispark, but the bindings should now build properly for:

- io/2.2.1
- io/2.3.1
- node/0.10.38
- node/0.12.5

:computer: